### PR TITLE
I fixed your thing...

### DIFF
--- a/vimtime
+++ b/vimtime
@@ -84,7 +84,7 @@ echo -e "\033[32mVim was installed.\033[0m"
 # wherever our .vimrc file goes.
 ###
 
-cat > .vimrc <<EOF
+cat > .vimrc <<'EOF'
 " general tweaks
 set nocompatible
 set ruler


### PR DESCRIPTION
When you do a <<EOF the default is string interpolation.

By wrapping it with single quotes, you force it to be literal without any interpolation.